### PR TITLE
fix genomic table

### DIFF
--- a/src/encoded/static/components/biospecimen.js
+++ b/src/encoded/static/components/biospecimen.js
@@ -147,7 +147,7 @@ class Biospecimen extends React.Component {
                     </div>
                     </PanelBody>
                 </Panel>
-                { hasGenomics && <GenomicsTable data={context.biolibrary} tableTitle="Genomics for this specimen"></GenomicsTable>}
+                {/* { hasGenomics && <GenomicsTable data={context.biolibrary} tableTitle="Genomics for this specimen"></GenomicsTable>} */}
                 {hasIHC&&<IHCTable data={context.ihc} tableTitle="IHC Assay Staining Results"></IHCTable>}
 
                 {false &&


### PR DESCRIPTION
Biospecimen are not linked to biolibrary anymore since we set the bioexperiment in. 

Close issue #322 
![image](https://user-images.githubusercontent.com/38848214/103546055-0c02af80-4e68-11eb-8a51-80bf09605a2f.png)

